### PR TITLE
Add Bambu Lab H2D profiles for ezPC+CF & Create .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode,macos
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+

--- a/CARBONX™ ezPC+CF/Bambu Labs/3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle.json
+++ b/CARBONX™ ezPC+CF/Bambu Labs/3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle.json
@@ -102,7 +102,7 @@
         "10"
     ],
     "filament_cost": [
-        "39.99"
+        "88"
     ],
     "filament_density": [
         "1.36"
@@ -125,9 +125,9 @@
     ],
     "filament_dev_ams_drying_time": [
         "12",
-        "4",
+        "8",
         "12",
-        "4"
+        "8"
     ],
     "filament_dev_chamber_drying_bed_temperature": [
         "90"
@@ -156,8 +156,8 @@
         "Direct Drive High Flow"
     ],
     "filament_flow_ratio": [
-        "0.94",
-        "0.94"
+        "0.9776",
+        "0.9776"
     ],
     "filament_flush_temp": [
         "0",
@@ -177,7 +177,7 @@
     ],
     "filament_max_volumetric_speed": [
         "8",
-        "8"
+        "12"
     ],
     "filament_minimal_purge_on_wipe_tower": [
         "15"
@@ -258,7 +258,7 @@
     ],
     "filament_retraction_length": [
         "nil",
-        "0.4"
+        "nil"
     ],
     "filament_retraction_minimum_travel": [
         "nil",

--- a/CARBONX™ ezPC+CF/Bambu Labs/3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle.json
+++ b/CARBONX™ ezPC+CF/Bambu Labs/3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle.json
@@ -1,0 +1,448 @@
+{
+    "activate_air_filtration": [
+        "0"
+    ],
+    "additional_cooling_fan_speed": [
+        "0"
+    ],
+    "chamber_temperatures": [
+        "65"
+    ],
+    "circle_compensation_speed": [
+        "200"
+    ],
+    "close_fan_the_first_x_layers": [
+        "6"
+    ],
+    "compatible_printers": [
+        "Bambu Lab H2D 0.4 nozzle"
+    ],
+    "compatible_printers_condition": "",
+    "compatible_prints": [],
+    "compatible_prints_condition": "",
+    "complete_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "cool_plate_temp": [
+        "100"
+    ],
+    "cool_plate_temp_initial_layer": [
+        "100"
+    ],
+    "cooling_perimeter_transition_distance": [
+        "10"
+    ],
+    "cooling_slowdown_logic": [
+        "uniform_cooling"
+    ],
+    "counter_coef_1": [
+        "0"
+    ],
+    "counter_coef_2": [
+        "0.008"
+    ],
+    "counter_coef_3": [
+        "-0.041"
+    ],
+    "counter_limit_max": [
+        "0.033"
+    ],
+    "counter_limit_min": [
+        "-0.035"
+    ],
+    "default_filament_colour": [
+        ""
+    ],
+    "diameter_limit": [
+        "50"
+    ],
+    "during_print_exhaust_fan_speed": [
+        "70"
+    ],
+    "enable_overhang_bridge_fan": [
+        "1"
+    ],
+    "enable_pressure_advance": [
+        "0"
+    ],
+    "eng_plate_temp": [
+        "100"
+    ],
+    "eng_plate_temp_initial_layer": [
+        "100"
+    ],
+    "fan_cooling_layer_time": [
+        "30"
+    ],
+    "fan_max_speed": [
+        "40"
+    ],
+    "fan_min_speed": [
+        "10"
+    ],
+    "filament_adaptive_volumetric_speed": [
+        "0",
+        "0"
+    ],
+    "filament_adhesiveness_category": [
+        "500"
+    ],
+    "filament_bridge_speed": [
+        "25",
+        "25"
+    ],
+    "filament_change_length": [
+        "4"
+    ],
+    "filament_change_length_nc": [
+        "10"
+    ],
+    "filament_cooling_before_tower": [
+        "10",
+        "10"
+    ],
+    "filament_cost": [
+        "39.99"
+    ],
+    "filament_density": [
+        "1.36"
+    ],
+    "filament_deretraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_dev_ams_drying_ams_limitations": [
+        "1"
+    ],
+    "filament_dev_ams_drying_heat_distortion_temperature": [
+        "105"
+    ],
+    "filament_dev_ams_drying_temperature": [
+        "65",
+        "80",
+        "65",
+        "80"
+    ],
+    "filament_dev_ams_drying_time": [
+        "12",
+        "4",
+        "12",
+        "4"
+    ],
+    "filament_dev_chamber_drying_bed_temperature": [
+        "90"
+    ],
+    "filament_dev_chamber_drying_time": [
+        "12"
+    ],
+    "filament_dev_drying_cooling_temperature": [
+        "90"
+    ],
+    "filament_dev_drying_softening_temperature": [
+        "90"
+    ],
+    "filament_diameter": [
+        "1.75"
+    ],
+    "filament_enable_overhang_speed": [
+        "1",
+        "1"
+    ],
+    "filament_end_gcode": [
+        "; filament end gcode \n"
+    ],
+    "filament_extruder_variant": [
+        "Direct Drive Standard",
+        "Direct Drive High Flow"
+    ],
+    "filament_flow_ratio": [
+        "0.94",
+        "0.94"
+    ],
+    "filament_flush_temp": [
+        "0",
+        "0"
+    ],
+    "filament_flush_volumetric_speed": [
+        "0",
+        "0"
+    ],
+    "filament_id": "P3f888b9",
+    "filament_is_support": [
+        "0"
+    ],
+    "filament_long_retractions_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_max_volumetric_speed": [
+        "8",
+        "8"
+    ],
+    "filament_minimal_purge_on_wipe_tower": [
+        "15"
+    ],
+    "filament_notes": "",
+    "filament_overhang_1_4_speed": [
+        "0",
+        "0"
+    ],
+    "filament_overhang_2_4_speed": [
+        "50",
+        "50"
+    ],
+    "filament_overhang_3_4_speed": [
+        "30",
+        "30"
+    ],
+    "filament_overhang_4_4_speed": [
+        "10",
+        "10"
+    ],
+    "filament_overhang_totally_speed": [
+        "10",
+        "10"
+    ],
+    "filament_pre_cooling_temperature": [
+        "0",
+        "0"
+    ],
+    "filament_pre_cooling_temperature_nc": [
+        "0",
+        "0"
+    ],
+    "filament_prime_volume": [
+        "30"
+    ],
+    "filament_prime_volume_nc": [
+        "60"
+    ],
+    "filament_printable": [
+        "3"
+    ],
+    "filament_ramming_travel_time": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_travel_time_nc": [
+        "0",
+        "0"
+    ],
+    "filament_ramming_volumetric_speed": [
+        "-1",
+        "-1"
+    ],
+    "filament_ramming_volumetric_speed_nc": [
+        "-1",
+        "-1"
+    ],
+    "filament_retract_before_wipe": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_length_nc": [
+        "14",
+        "14"
+    ],
+    "filament_retract_restart_extra": [
+        "nil",
+        "nil"
+    ],
+    "filament_retract_when_changing_layer": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_distances_when_cut": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_length": [
+        "nil",
+        "0.4"
+    ],
+    "filament_retraction_minimum_travel": [
+        "nil",
+        "nil"
+    ],
+    "filament_retraction_speed": [
+        "nil",
+        "nil"
+    ],
+    "filament_scarf_gap": [
+        "0%"
+    ],
+    "filament_scarf_height": [
+        "10%"
+    ],
+    "filament_scarf_length": [
+        "10"
+    ],
+    "filament_scarf_seam_type": [
+        "none"
+    ],
+    "filament_settings_id": [
+        "3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle"
+    ],
+    "filament_shrink": [
+        "100%"
+    ],
+    "filament_soluble": [
+        "0"
+    ],
+    "filament_start_gcode": [
+        "; filament start gcode\n"
+    ],
+    "filament_tower_interface_pre_extrusion_dist": [
+        "10"
+    ],
+    "filament_tower_interface_pre_extrusion_length": [
+        "0"
+    ],
+    "filament_tower_interface_print_temp": [
+        "-1"
+    ],
+    "filament_tower_interface_purge_volume": [
+        "20"
+    ],
+    "filament_tower_ironing_area": [
+        "4"
+    ],
+    "filament_type": [
+        "PC"
+    ],
+    "filament_velocity_adaptation_factor": [
+        "1"
+    ],
+    "filament_vendor": [
+        "3DXTECH"
+    ],
+    "filament_wipe": [
+        "1",
+        "1"
+    ],
+    "filament_wipe_distance": [
+        "1",
+        "1"
+    ],
+    "filament_z_hop": [
+        "nil",
+        "nil"
+    ],
+    "filament_z_hop_types": [
+        "Spiral Lift",
+        "Spiral Lift"
+    ],
+    "first_x_layer_fan_speed": [
+        "0"
+    ],
+    "from": "User",
+    "full_fan_speed_layer": [
+        "0"
+    ],
+    "hole_coef_1": [
+        "0"
+    ],
+    "hole_coef_2": [
+        "-0.008"
+    ],
+    "hole_coef_3": [
+        "0.23415"
+    ],
+    "hole_limit_max": [
+        "0.22"
+    ],
+    "hole_limit_min": [
+        "0.088"
+    ],
+    "hot_plate_temp": [
+        "100"
+    ],
+    "hot_plate_temp_initial_layer": [
+        "100"
+    ],
+    "impact_strength_z": [
+        "9"
+    ],
+    "inherits": "",
+    "long_retractions_when_ec": [
+        "1",
+        "1"
+    ],
+    "name": "3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle",
+    "no_slow_down_for_cooling_on_outwalls": [
+        "0"
+    ],
+    "nozzle_temperature": [
+        "270",
+        "280"
+    ],
+    "nozzle_temperature_initial_layer": [
+        "270",
+        "270"
+    ],
+    "nozzle_temperature_range_high": [
+        "280"
+    ],
+    "nozzle_temperature_range_low": [
+        "260"
+    ],
+    "overhang_fan_speed": [
+        "60"
+    ],
+    "overhang_fan_threshold": [
+        "25%"
+    ],
+    "overhang_threshold_participating_cooling": [
+        "95%"
+    ],
+    "override_process_overhang_speed": [
+        "0",
+        "0"
+    ],
+    "pre_start_fan_time": [
+        "0"
+    ],
+    "pressure_advance": [
+        "0.02"
+    ],
+    "reduce_fan_stop_start_freq": [
+        "1"
+    ],
+    "required_nozzle_HRC": [
+        "3"
+    ],
+    "retraction_distances_when_ec": [
+        "10",
+        "10"
+    ],
+    "slow_down_for_layer_cooling": [
+        "1"
+    ],
+    "slow_down_layer_time": [
+        "12"
+    ],
+    "slow_down_min_speed": [
+        "20",
+        "20"
+    ],
+    "supertack_plate_temp": [
+        "0"
+    ],
+    "supertack_plate_temp_initial_layer": [
+        "0"
+    ],
+    "temperature_vitrification": [
+        "127"
+    ],
+    "textured_plate_temp": [
+        "100"
+    ],
+    "textured_plate_temp_initial_layer": [
+        "100"
+    ],
+    "version": "2.5.0.5",
+    "volumetric_speed_coefficients": [
+        "0 0 0 0 0 0",
+        "0 0 0 0 0 0"
+    ]
+}

--- a/CARBONX™ ezPC+CF/Bambu Labs/3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle.json
+++ b/CARBONX™ ezPC+CF/Bambu Labs/3DXTECH PC ezPC+CF @Bambu Lab H2D 0.4 nozzle.json
@@ -374,7 +374,7 @@
     ],
     "nozzle_temperature": [
         "270",
-        "280"
+        "270"
     ],
     "nozzle_temperature_initial_layer": [
         "270",


### PR DESCRIPTION
First installment of H2D profiles for ezPC+CF. Nozzles used:

- Bambu 0.4mm Standard Flow
- E3D Obxidian 500 0.4mm High-Flow 

Yes, while the E3D nozzle has a greater flow rate than the Bambu HF nozzles, I kept the flow rates conservative, so they'll be fine on the Bambu HF 0.4mm nozzles.

Post-creation, I've been printing parts for a new VSpooler-X, and they're coming out great using both Standard and HF nozzles.

Models I use for my calibration/profile creation process (in addition to referencing published TDS, etc. documentation):

- Orca Slicer Temp Tower (I just create the tower in Orca & export, then import to Bambu Studio and set the temp changes as additional G-Code bits in the sliced models)
- [RevHazlett's Flow Ratio Calibration Card](https://makerworld.com/en/models/2214651-rev-s-flow-rate-calibration-card#profileId-2407780)
- [Engineered Reality's Max Volumetric Flow](https://makerworld.com/en/models/1786711-0-4-bambu-slicer-2-2-max-flow-test-up-to-50mm3-s#profileId-1903836) (I had to use his "TPU version" to accommodate lower flow rates. Nothing TPU specific, just lower flow rates in there.
- Typical 3DBenchy to verify print quality.

I also added a .gitignore file that ignores typical metadata files for macOS (.DS_Store, etc.) and VS Code (.vscode/ directory, etc.). This will keep the repo from getting accidental additions from macOS and VS Code users. 

